### PR TITLE
Added a shift to colswap in _perform_row_operations

### DIFF
--- a/stac/code.py
+++ b/stac/code.py
@@ -199,7 +199,7 @@ def _perform_row_operations(A: Any,
         is a list of length three. The first entry is one of {colswap, rowswap
         addrow}. The next two arguments determine which rows to swap or add.
     start_row : int, optional
-        Shift the start row of the operations. The default is 0.
+        Shift the start row and column of the operations. The default is 0.
 
     Returns
     -------
@@ -211,7 +211,8 @@ def _perform_row_operations(A: Any,
 
     for op in ops:
         if op[0] == "colswap":
-            M[:, [op[1], op[2]]] = M[:, [op[2], op[1]]]
+            M[:,[start_row + op[1], start_row + op[2]]] = \
+                M[:,[start_row + op[2], start_row + op[1]]]
         elif op[0] == "rowswap":
             M[[start_row + op[1], start_row + op[2]], :] = \
                 M[[start_row + op[2], start_row + op[1]], :]


### PR DESCRIPTION
When performing operations on the bimatrices of Code objects for finding the standard form one needed to take into account the shift given by start_row. This comes from the fact that first, one finds the rref of the left sub matrix A and then the rref of the right sub sub matrix E. After finding A, one needs to shift the row operations we are performing a number of start_row=self.rankx elements to the right so one does not mess with the identity that is on the left already and this was implemented in the code as it should. However, one should also shift the column operations in order to avoid messing with the aforementioned identity and this was not considered in the code. 

I don't believe though that this sole change will fix #2 .